### PR TITLE
220106

### DIFF
--- a/15_copy_constructor3.cpp
+++ b/15_copy_constructor3.cpp
@@ -32,6 +32,10 @@ Point &hoo()
     // 사라지는 메모리에 대한 참조를 반환하는 것은 미정의 사항이다.
 }
 
+// lvalue
+// rvalue
+// a = 3;
+
 int main()
 {
     foo()

--- a/18_thread.cpp
+++ b/18_thread.cpp
@@ -1,0 +1,30 @@
+// #include <thread>   // C++11
+#include <pthread.h>    // 기존에 사용
+#include <unistd.h>
+
+#include <iostream>
+using namespace std;
+
+void *foo(void *foo)
+{
+    for (int i = 0; i < 10000000; ++i)
+    {
+        usleep(20000);
+        cout << "foo" << endl;
+    }
+
+    return nullptr;
+}
+
+int main()
+{
+    pthread_t thread;
+    pthread_create(&thread, nullptr, &foo, nullptr);
+    for (int i = 0; i < 10000000; ++i)
+    {
+        usleep(100000);
+        cout << i << endl;
+    }
+}
+
+// g++ 18_thread.cpp -lpthread

--- a/18_thread2.cpp
+++ b/18_thread2.cpp
@@ -1,0 +1,76 @@
+// 스레드의 특성
+// 1. pthread_create
+//  : 스레드를 생성하고, 스레드가 만들어져서 시작할 함수를 지정한다.
+// 2. 스레드는 자신만의 스택을 가지고 있다.
+// 3. 모든 스레드는 같은 프로세스 내에서 동작하기 때문에 데이터를 쉽게 공유할 수 있다.
+#include <iostream>
+#include <pthread.h>
+using namespace std;
+
+int sum = 0;
+
+pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void *thread_routine(void *arg)
+{
+    printf("%s\n", (char *)arg);
+    
+    for (int i = 0; i < 1000000; ++i)
+    {
+        //----
+        pthread_mutex_lock(&g_mutex);
+        sum += 1;
+        pthread_mutex_unlock(&g_mutex);
+        //---- 임계 영역(Critical Section)
+        //  : 오직 한개의 스레드만 접근 가능하도록 해야한다.
+        //      - 상호 배제(Mutual exclustion)
+        //          : 상호 배제 하는 역할을 Mutex
+
+        // 원인
+        //  : 두개 이상의 스레드가 sum이라는 메모리에 연산을 동시에 수행할 경우, 레이드 컨디션이 발생한다.
+        // > sum에 +1을 하는 연산은 원자적이지 않다.
+    }
+    
+    // mutex는 정체 현상을 야기할 수 있기 때문에 독립적으로 돌은 다음 결과를 병합하는 모델이 가장 좋다.
+    // ->
+    int local = 0;
+    for (int i = 0; i < 1000000; ++i)
+    {
+        local += 1;
+    }
+    pthread_mutex_lock(&g_mutex);
+    sum += local;
+    pthread_mutex_unlock(&g_mutex);
+    // lock을 100만번씩 하지 않아도 된다.
+
+    return nullptr;
+
+}
+
+// 4. 프로세스가 처음 만들어졌을 때, main 함수를 실행하는 흐름을 '메인 스레드' 라고 부른다.
+// 5. 메인 함수가 반환하면, 프로세스가 종료한다.
+//    메인 함수의 반환은 프로세스 내의 모든 스레드가 종료된다.
+
+// 6. pthread_join 함수를 통해 스레드의 종료까지 대기할 수 있다.
+int main()
+{
+    cout << "main thread start" << endl;
+    pthread_t thread[2]; // 스레드 핸들
+
+    for (int i = 0; i < 2; ++i)
+    {
+        const char *arg = i == 0 ? "A" : "B";
+        
+
+        pthread_create(&thread[i], nullptr, &thread_routine, (void *)arg);
+    }
+
+    // getchar();
+    for (int i = 0; i < 2; ++i)
+    {
+        pthread_join(thread[i], nullptr);
+    }
+    printf("sum: %d\n", sum);
+    // 결과가 제대로 나오지 않는 이유를 이해해야 한다.
+}
+

--- a/18_thread3.cpp
+++ b/18_thread3.cpp
@@ -1,0 +1,45 @@
+// 18_thread3.cpp
+// C++11 부터 스레드를 표준 라이브러리를 통해 지원한다.
+#include <iostream>
+#include <thread>
+#include <mutex>
+
+#if 0
+void foo() 
+{
+    std::cout << "foo" << std::endl;
+}
+
+int main()
+{
+    std::cout << "main thread" << std::endl;
+    std::thread t1(&foo);
+
+    t1.join(); // 스레드 종료 할때까지 대기
+}
+#endif
+
+int sum = 0;
+std::mutex m;
+
+void thread_routine(const char* name)
+{
+    std::cout << name << std::endl;
+    for (int i = 0; i < 1000000; ++ i)
+    {
+        m.lock();
+        sum += 1;
+        m.unlock();
+    }
+}
+
+int main()
+{
+    std::thread t1(&thread_routine, "A");
+    std::thread t2(&thread_routine, "B");
+
+    t1.join();
+    t2.join();
+
+    std::cout << "sum: " << sum << std::endl;
+}

--- a/19_this.cpp
+++ b/19_this.cpp
@@ -1,0 +1,58 @@
+// 19_tihs.cpp
+#include <iostream>
+using namespace std;
+
+class Point
+{
+private:
+    int x;
+    int y;
+
+public:
+    // this : 멤버 함수를 호출한 객체의 주소가 전달된다.
+    void set(int a, int b)  // 실제 컴파일러는 이 set함수에 대해 다음과 같이 만듬 void set(Point* const this, int a, int b)
+    {                       
+        x = a;              // this->x = a;
+        y = b;              // tihs->y = b;
+    }
+
+    void foo()  // void foo(Point* const this)
+    {
+        cout<< this << endl;
+    }
+
+    // 정적멤버함수는 객체가 생성되지 않아도 호출될 수 있다.
+    // > 멤버 변수와 멤버 함수를 사용할 수 없다.
+    // -> this가 전달되지 않는다.
+    static void goo() {}
+
+    static int add(int a, int b) { return a + b; }
+    int hoo(int a, int b) { reutrn a + b; }
+    // hoo의 타입: int(Point* const this, int, int)
+};
+
+// 일반 함수
+int sub(int a, int b)
+{
+    return a - b;
+}
+
+int main()
+{
+    // Point::add의 타입은 무엇인가?
+    // => int(int, int)
+
+    int (*fp)(int, int) = &Point::add;
+    fp = &sub;
+
+    Point p1;
+    Point p2;
+
+    p1.set(10, 20);     // Point::set(&p1, 10, 20);
+    p2.set(20, 30);     // Point::set(&p2, 20, 30);
+
+    cout << &p1 << endl;
+    p1.foo();
+    cout << &p2 << endl;
+    p2.foo();
+}

--- a/19_this2.cpp
+++ b/19_this2.cpp
@@ -1,0 +1,105 @@
+#include <iostream>
+#include <string>
+using namespace std;
+
+#if 0
+// this 활용
+// - 멤버 변수 이름과 함수 인자 이름이 동일할 때, 멤버 변수를 명시적으로 접근할 때 사용한다.
+
+// 초기화 리스트에서 this->xxx 형식으로 초기화가 불가능하다.(생성자에서 불가능)
+// 멤버 변수 이름과 동일한 인자를 받을 경우, this를 명시적으로 작성해주어야 한다.
+//  > 멤버 데이터는 이름의 뒤에 언더스코어 형식을 권장한다.
+class User
+{
+    std::string name;
+    int age;
+
+public:
+    User(const std::string& name, int age) : name_(name), age_(age){} 
+
+    void set(const std::string& name, int age)
+    {
+        // this->name = name;
+        // this->age = age;
+        // this 안쓰고 언더스코어로도 사용할 수 있다.
+        name_ = name;
+        age_ = age;
+    }
+};
+
+int main()
+{
+    User user1("Tom", 42)
+}
+#endif
+
+// 활용 2.
+//      연쇄 호출(체이닝)
+
+class User{
+private:
+    std::string name;
+    std::string address;
+    std::String phone;
+
+public:
+// 1번
+#if 0
+    void SetName(const std::string& name) { name_ = name; }
+    void SetAddress(const std::string& address) { address_ = address; }
+    void SetPhone(const std::string& phone) { phone_ = phone; }
+#endif
+
+// 2번
+#if 0
+    User* SetName(const std::string& name)
+    {
+        name_ = name;
+        return this;
+    }
+    User* SetAddress(const std::string& address)
+    {
+        address_ = address;
+        return this;
+    }
+    User* SetPhone(const std::string& phone)
+    {
+        phone_ = phone;
+        return this;
+    }
+#endif
+
+// 3번
+    User& SetName(const std::string& name)
+    {
+        name_ = name;
+        return *this;
+    }
+    User& SetAddress(const std::string& address)
+    {
+        address_ = address;
+        return *this;
+    }
+    User& SetPhone(const std::string& phone)
+    {
+        phone_ = phone;
+        return *this;
+    }
+
+};
+
+int main()
+{
+    User user;
+
+    // 1번
+    // user.SetName("Tom");
+    // user.SetAddress("Seoul");
+    // user.SetPhone("010-1234-1234");
+
+    // 2번
+    // user.SetName("Tom")->SetAddress("Seoul")->SetPhone("010-1234-1234");
+
+    // 3번
+    user.SetName("Tom").SetAddress("Seoul").SetPhone("010-1234-1234")
+}

--- a/20_inheritance.cpp
+++ b/20_inheritance.cpp
@@ -1,0 +1,49 @@
+// 20 inheritance.cpp
+// 상속
+#include <iostream>
+#include <string>
+using namespace std;
+
+#if 0
+class Student
+{
+private:
+    string name;
+    int age;
+    int id;
+};
+
+class Professor
+{
+private:
+    string name;
+    int age;
+    int major;
+};
+#endif
+// 상속 문법을 이용하면 공통의 속성을 관리하는 것이 편리하다.
+// > 공통의 속성을 가진 타입을 설계한다.
+
+// Base / Super 클래스라고 부른다.
+class User
+{
+private:
+    string name;
+    int age;
+};
+
+// Derived / Sub 클래스라고 부른다.
+class Student : public User
+{
+private:
+    int id;
+};
+
+class Professor : public User
+{
+private:
+    int major;
+};
+
+int main(){}
+

--- a/20_inheritance2.cpp
+++ b/20_inheritance2.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <string>
+using namespace std;
+
+
+// 상속과 접근 지정자
+// - private
+//      : 자신의 멤버 함수 안에서만 접근이 가능하고, 외부에서는 접근이 불가능하다.
+//      > 자식 클래스에서 부모 클래스의 private 멤버 함수와 멤버 변수를 접근할 수 없다.
+
+// - protected
+//      : 외부에서는 접근이 불가능하고, 자식 클래스를 통해서는 접근이 가능하다.
+
+// - public
+//      : 어디서든 접근이 가능하다.
+class User
+{
+private:
+    int age;
+    string name;
+
+protected:
+    std::string GetName() const { return name; }
+};
+
+class Student : public User
+{
+private:
+    int id;
+
+public:
+    // 부모의 상태에 접근하는 모든 기능은 부모가 제공하는 멤버 함수를 통해서 이루어져야 한다.
+    void PrintName() 
+    { 
+        // cout << name << endl; 
+        cout <<GetName() << endl;
+    }
+};
+
+
+
+int main() {}
+
+// SOLID
+//      > 객체 지향 설계 5대 원칙
+// 1. SRP(단일 책임 원칙)
+//  : 모든 모듈은 단 하나의 책임을 가져야 한다.
+// 2. OCP(개방 폐쇄 원칙)
+//  : 수정에는 닫혀 있고, 확장에는 열려 있어야한다.
+//  새로운 기능이 추가되어도, 기존 코드는 수정되면 안된다.
+// 3. LSP
+// 4. ISP
+// 5. DIP

--- a/20_inheritance3.cpp
+++ b/20_inheritance3.cpp
@@ -1,0 +1,34 @@
+#include <iostream>
+using namespace std;
+
+// 상속과 생성자 / 소멸자
+class Base
+{
+public:
+    Base() { cout << "Base()" << endl; }
+    Base(int a) { cout << "Base(int)" << endl; }
+
+    ~Base() { cout << "~Base()" << endl; }
+};
+
+class Derived : public Base
+{
+public:
+    // 원리: 컴파일러는 자식 클래스의 생성자에서 초기화 리스트를 통해 부모의 기본 생성자를 호출하는 코드를 삽입한다.
+    Derived() { cout << "Derived()" << endl; }
+
+    // 컴파일러에서 자동으로 다음과 같은 코드를 호출한다.
+    // Derived() : Base() { cout << "Derived()" << endl; }
+
+    // int 인자를 갖는 Base생성자를 호출하고 싶으면 다음과 같이 작성한다.
+    // Derived() : Base(42) { cout << "Derived()" << endl; }
+    
+    ~Derived() { cout << "~Derived()" << endl; }
+    // ~Base();
+    // 컴파일러가 자동으로 삽입해서 호출해준다.
+};
+
+int main()
+{
+    Derived d;
+}

--- a/20_inheritance4.cpp
+++ b/20_inheritance4.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+using namespace std;
+
+class Animal
+{
+    public:
+protected:
+    Animal() {}
+};
+
+class Dog : public Animal
+{
+    public:
+    // Dog() {}
+    Dog() : Animal() {}
+};
+
+// protected 생성자의 의도
+// "자신 타입의 객체는 생성할 수 없지만, 파생 클래스 타입의 객체는 생성할 수 있다."
+
+int main()
+{
+    Animal a;   // 생성자를 protected로 만드는 순간 error 발생
+    Dog d;      // ok!
+                // Dog의 생성자를 먼저 호출하고, Dog의 생성자 안에서 Animal 생성자를 호출한다.
+                // 파생 클래스에서는 기반 클래스의 protected 멤버에 접근이 가능하다.
+}

--- a/21_virtual.cpp
+++ b/21_virtual.cpp
@@ -1,0 +1,40 @@
+// 21_virtual.cpp
+#include <iostream>
+using namespace std;
+
+class Animal() 
+{
+public:
+    int age;
+};
+
+class Dog : public Animal 
+{
+public:
+    int color;
+};
+
+
+#if 0
+int main()
+{
+    double d = 3.14;
+    int* p = &d;
+    // error! double의 주소를 int*에 담을 수 없다.
+}
+#endif
+
+// Animal <--- Dog
+// 상속: is-a 관계가 상속된다.
+//  "자식 클래스 is a 부모 클래스"
+//  => Dog is a Animal
+
+int main()
+{
+    Dog d; // 자식 클래스
+    Animal* p = &d;
+    // 기반 클래스의 포인터 타입으로 자식 클래스의 객체의 주소를 담을 수 있다.
+    // => 암묵적인 변환이 허용된다.
+    // => Upcasting
+    
+}

--- a/21_virtual2.cpp
+++ b/21_virtual2.cpp
@@ -1,0 +1,31 @@
+// 21_virtual2.cppp
+#include <iostream>
+using namespace std;;
+class Animal
+{
+public:
+    int age;
+
+};
+
+class Dog : public Animal
+{
+public:
+    int color;
+};
+
+class Cat : public Animal {};   // -> 상송받는게 여러개일 경우 명확하지 않기 때문에 다운캐스팅시에는 명시적인 캐스팅이 필요하다.
+
+int main()
+{
+    // 업캐스팅
+    Animal *p1 = new Dog;
+
+    Dog d;
+    Animal *p2 = &d;
+
+    //다운캐스팅
+    // 부모의 포이인터 타입을 자식의  포인터 타입으로의 암묵적 변환은 허용되지 않는다.
+    // => 명시적인 캐스팅이 필요하다.
+    Dog *pDog = static_cast<Dog*>(p1);
+}

--- a/21_virtual3.cpp
+++ b/21_virtual3.cpp
@@ -1,0 +1,75 @@
+// Upcasting 활용
+#include <iostream>
+using namespace std;;
+class Animal
+{
+public:
+    int age;
+
+};
+
+class Dog : public Animal
+{
+public:
+    int color;
+};
+
+class Cat : public Animal {}; 
+
+// 1. 동종(같은 부모를 갖는 클래스)을 처리하는 함수를 만들 수 있다.
+
+// bool IsOlderThan10YearsOld(Dog* p)
+// {
+//     return p->age >10;
+// }
+
+// bool IsOlderThan10YearsOld(Cat* p)
+// {
+//     return p->age >10;
+// }
+
+// 부모의 동일한 속성을 사용하기 떄문에 하나의 함수로 처리할 수 있다.
+bool IsOlderThan10YearsOld(Animal* p)
+{
+    return p->age >10;
+}
+#if 0
+int main()
+{
+    Dog d;
+    Cat c;
+
+    IsOlderThan10YearsOld(&d);
+    IsOlderThan10YearsOld(&c);
+}
+#endif
+
+#if 0
+#include <vector>
+int main()
+{
+    vector<Dog*> v1 // Dog타입만 보관할 수 있다.
+    
+    Dog d;
+    Cat c;
+    v1.push_back(&d);
+    // v1.push_back(&c); // - error!
+    
+    // 2. 동종을 보관하는 컨테이너를 만들 수 있다.
+    vector<Animal*> v2; // Animal의 모든 파생 클래스 타입도 보관이 가능하다.
+    v2.push_back(&d);
+    v2.push_back(&c);
+}
+#endif
+
+// 파일과 폴더의 공통의 기반 클래스를 만든다.
+
+// 폴더 안에는 파일도 있고 폴더도 있다.
+// > 파일과 폴더의 공통의 부모가 존재하면, 하나의 컨테이너를 통해 관리하는 것이 가능하다.
+class Item {};
+
+class File : public Item {};
+class Folder : public Item 
+{
+    vector<Item*> v;
+};

--- a/21_virtual4.cpp
+++ b/21_virtual4.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+using namespace std;
+
+class Animal
+{
+public:
+    virtual void Cry() { cout << "Animal cry" << endl; }    // 1
+};
+
+class Dog : public Animal 
+{
+public:
+    //기반 클래스의 멤버 함수를 자식 클래스에서 다시 재정의할 수 있다.
+    // => 함수 오버라이딩
+    virtual void Cry() { cout << "Dog cry" << endl; }       // 2
+    // 자식이 재정의하는 부모의 멤버 함수는 반드시 가상 함수여야 한다.
+};
+
+// C++ 함수 바인딩
+// - 어떤 함수를 호출할지 결정하는 것
+//  p -> Cry()의 후보
+//      * Animal::Cry()
+//      * Dog::Cry()
+// 정적 바인딩: Animal::Cry()
+//  - 컴파일러가 p의 타입(Animal*)을 보고 Animal의 함수를 호출하도록 기계어를 생성한다.
+// 동적 바인딩: Dog::Cry()
+//  - 컴파일러가 실행 시간에 p가 어떤 타입인지를 조사해서, 해당 타입의 호출하도록 하는 기계어를 생성한다.
+//  - 실행 시간에 결정되는 p의 타입에 따라 호출되는 함수가 달라진다.
+// 동적 바인딩을 만들어주기 위해 멤버 함수에 virtual을 입력한다.
+int main()
+{
+    Animal a;
+    Dog d;
+
+    //Upcasting
+    Animal* p = &d;
+    p->Cry(); // 1? 2?
+
+    a.Cry();
+    d.Cry();
+}
+
+// 함수 오버로딩: 동일한 함수를 인자를 다르게 하여 정의하는 것
+// 함수 오버라이딩: 부모의 함수를 자식에서 재정의하는 것

--- a/21_virtual5.cpp
+++ b/21_virtual5.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+using namespace std;
+
+// 1. 부모의 멤버 함수가 virtual 이면 자식 멤버 함수도 virutal이 된다.
+
+class Animal
+{
+public:
+    virtual void Cry() { cout << "Animal cry" << endl; }
+};
+
+class Dog : public Animal
+{
+public:
+    // virtual void Cry() { cout << "Dog cry" << endl; }
+    // virtual은 선언과 구현을 분리할 때 선언에만 사용된다.
+
+    // 아래 함수가, 부모의 함수를 오버라이딩 한 것인지 아닌것인지 확인이 어렵다.
+    // C++11 에서는 부모로부터 오버라이딩 한 함수라는 표시를 할 수 있다. -> override붙이기
+    // virtual void Cry() override;
+    // 요즘은 아래와 같이 씀
+    void Cry() override;
+};
+
+// Dog.cpp
+//virtual, override, static: 선언부에만 사용한다.
+void Dog::Cry()
+{
+    cout << "Dog cry" << endl;
+}
+
+int main()
+{
+    Animal* p = new Dog;
+
+    p->Cry();
+}

--- a/21_virtual6.cpp
+++ b/21_virtual6.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+using namespace std;
+
+#if 0
+class Test
+{
+public:
+    Test() { cout << "자원 획득" << endl; }
+    ~Test() { cout << "자원 반납" << endl; }
+};
+
+int main()
+{
+    // Test t;
+    Test* t = new Test;
+    delete t;
+}
+#endif
+
+class Base
+{
+public:
+    Base() { cout << "Base()" << endl; }
+    virtual ~Base() { cout << "~Base()" << endl; }
+};
+
+class Derived : public Base
+{
+public:
+    Derived() { cout << "Derived()" << endl; }
+    virtual ~Derived() { cout << "~Derived()" << endl; }
+};
+
+int main()
+{
+    // Derived d;
+
+    Base* p = new Derived;  // -> 자식의 소멸자가 실행되지 않음 : 누수 발생
+    delete p;
+    // 소멸자도 함수이다.
+    // 일반적인 소멸자는 정적 바인딩 기반으로 동작한다.
+    // 업캐스팅의 기반으로 코드를 작성할 경우, 반드시 소멸자가 가상 소멸자이여야 한다.
+}


### PR DESCRIPTION
# 강의요약
## thread
- thread의 특성
    - 1. pthread_create: 스레드를 생성하고, 시작할 함수를 지정한다.
    - 2. 스레드는 자신만의 스택을 갖고있다.
    - 3. 모든 스레드는 같은 프로세스 내에서 동작하기 때문에 데이터를 쉽게 공유할 수 있다.
    - 4. 프로세스가 처음 만들어졌을 때, main함수를 실행하는 흐름을 '메인 스레드' 라고 부른다.
    - 5. 메인 함수가 반환하면 프로세스가 종료되며 프로세스 내의 모든 스레드가 종료된다.
    - 6. pthread join을 통해 스레드의 종료까지 대기할 수 있다.
- 단순히 여러개의 스레드를 동시에 실행시키면 레이드 컨디션이 발생한다.
- 이를 방지하기 위해 상호 배제(Mutual exclusion)을 사용한다.
- pthread_mutex_lock, unlock을 통해 해결할 수 있으며, 이를 통해 오직 하나의 스레드만 접근이 가능하게 해준다.
- 단, mutex는 정체 현상을 야기할 수 있기 때문에 독립적으로 실행시킨 후 결과를 병합하는 모델이 좋다.
- C++11부터 스레드를 표준 라이브러리를 통해 지원한다.
```cpp
#include <thread>
#include <mutex>
```
> 자세한 코드는 18번 파일 참조

## this
- this는 멤버 함수를 호출한 객체의 주소값을 가르킨다.
- 멤버 함수에 대해 실제 컴파일러는 this를 인자로 갖고있는 형태로 만든다.
```cpp
void set(int a, int b) -> void set(class_name* const this, int a, int b)
```
- 정적 멤버함수(static)는 객체가 생성되지 않아도 호출된다.
- 즉, this가 전달되지 않기 때문에 멤버 변수와 멤버 함수를 사용할 수 없다
- 따라서 this를 활용할 때는 멤버 변수 이름과 함수 인자 이름이 동일할 때, 멤버 변수를 명시적으로 접근할 때 사용한다.
    - 단, 초기화 리스트에서는 'this->xxx' 와 같은 방법으로 초기화가 불가능하다.(생성자에서 불가능)
    - 이런 경우 멤버 데이터는 이름의 뒤에 언더스코어 형식을 권장한다.
- 또는, 연쇄 호출(체이닝)을 할때 사용한다.
> 자세한 코드는 19번 파일 참조

## inheritance(상속)
- 상속을 사용하면 공통의 속성을 관리하는 것이 편리하다.
- Derived / Sub 클래스라고 부른다.
- 접근 지정자에는 private와 public이 있다고 하였다.
- 하지만 private를 사용하면 자식 클래스에서도 접근이 불가능하다.
- protected 접근 지정자를 사용하면, 자식 클래스를 통해 접근이 가능해진다.
- 또한, 부모의 상태에 접근하는 모든 기능은 부모가 제공하는 멤버 함수를 통해 이루어져야한다.
> SOLID원칙(객체 지향 설계 5대 원칙)
    1. SRP(단일 책임 원칙)
    : 모든 모듈은 단 하나의 책임을 가져야 한다.
    2. OCP(개방 폐쇄 원칙)
    : 수정에는 닫혀 있고, 확장에는 열려있어야한다.
    -> 새로운 기능이 추가되어도 기존 코드는 수정되면 안된다.
    3. LSP
    4. ISP
    5. DIP
- 컴파일러는 자식 클래스의 생성자에서 초기화 리스트를 통해 부모의 기본 생성자를 호출하는 코드를 삽입하게 된다.

## virtual
- int 포인터에 double의 주소를 담을 수 없다
- 단, 상속 관계의 경우 컴파일러가 암묵적으로 허용해준다.(is-a관계)
> is-a관계
    "자식 클래스" is a "부모 클래스"
- 부모 클래스가 자식 클래스의 주소를 담는 경우를 Upcasting이라고 한다.
- 단, 부모 클래스의 주소를 자식 클래스가 담는 것(Downcasting)은 허용해주지 않는다.
- 이를 하기 위해서는 명시적인 캐스팅이 필요하다. (상속받는게 여러개일 경우 명확하지 않기 떄문에)
- 상속을 사용하면 하나의 함수로 처리할 수 있으며, 동종(같은 부모를 갖는 클래스)을 보관하는 컨테이너를 만들 수 있다.
- 부모 클래스의 멤버 함수를 자식 클래스에서 다시 재정의 할 수 있다. (오버라이딩)
- 단, 이때 자식이 재정의하는 부모의 멤버 함수는 반드시 가상 함수여야 한다.(virtual)
- 컴파일러는 기본적으로 정적 바인딩을 수행하기 때문에 항상 부모 클래스의 함수를 호출하도록 기계어를 생성한다.
- 따라서 사용자는 이를 동적 바인딩으로 만들어주어 포인터의 타입에 따라 호출되는 함수가 달라지도록 할 필요가 있다.
- 이를 virtual을 입력하여 해결한다.
- 부모의 멤버함수가 virtual이면, 자식의 멤버함수도 virtual이 된다.
- virtual은 선언과 구현을 분리할 때 선언에서만 사용한다.
- C++11부터는 오버라이딩 한 함수를 표시 할 수 있다.
- 함수의 뒤에 override를 붙인다.(이러면 virtual이 없어도 됨)
- 생성자의 경우 부모 포인터에 자식의 주소를 담으면 부모와 자식 클래스의 생성자가 모두 호출된다.
- 하지만, 소멸자의 경우 자식의 소멸자는 실행되지 않는다.
- 소멸자는 정적 바인딩을 기반으로 동작하기 때문이다.
- 따라서 Upcasting을 기반으로 코드를 작성할 경우, 반드시 소멸자가 가상 소멸자이여야 한다.